### PR TITLE
feat: adding basic config model generation

### DIFF
--- a/config/build.gradle.kts
+++ b/config/build.gradle.kts
@@ -31,7 +31,7 @@ tasks.test {
 
 swaggerSources {
   register("valhalla") {
-      val openApiFile = file("../openapi.yaml")
+      val openApiFile = file("../openapi-config.yaml")
       require(openApiFile.exists()) { "OpenAPI spec file not found: $openApiFile" }
 
       setInputFile(openApiFile)
@@ -40,7 +40,7 @@ swaggerSources {
           components = listOf("models")
           additionalProperties = mapOf(
               "groupId" to "com.valhalla",
-              "packageName" to "com.valhalla.api"
+              "packageName" to "com.valhalla.config"
           )
           rawOptions = listOf(
               "--skip-validate-spec"
@@ -80,7 +80,7 @@ publishing {
             from(components["java"])
 
             groupId = "com.valhalla"
-            artifactId = "api"
+            artifactId = "config"
             version = libraryVersion
         }
     }

--- a/config/src/test/kotlin/TestConfig.kt
+++ b/config/src/test/kotlin/TestConfig.kt
@@ -1,0 +1,19 @@
+import com.valhalla.config.models.AdditionalData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AdditionalDataTest {
+  @Test
+  fun testDefault() {
+    val additionalData = AdditionalData()
+    assertEquals("/custom_files/elevation_data", additionalData.elevation)
+  }
+
+  @Test
+  fun testCustom() {
+    val additionalData = AdditionalData(
+      "/folder/elevation_data"
+    )
+    assertEquals("/folder/elevation_data", additionalData.elevation)
+  }
+}

--- a/openapi-config.yaml
+++ b/openapi-config.yaml
@@ -1,0 +1,637 @@
+openapi: 3.0.1
+info:
+  version: 3.0.4
+  title: Valhalla Config Definition
+  contact:
+    name: Valhalla
+    url: 'https://github.com/valhalla/valhalla'
+components:
+  schemas: 
+    additional_data: 
+      type: object
+      properties: 
+        elevation: 
+          type: string
+          default: /custom_files/elevation_data
+    httpd: 
+      type: object
+      properties: 
+        service: 
+          type: object
+          properties: 
+            drain_seconds: 
+              type: number
+              default: 28
+            interrupt: 
+              type: string
+              default: ipc:///tmp/interrupt
+            listen: 
+              type: string
+              default: tcp://*:8002
+            loopback: 
+              type: string
+              default: ipc:///tmp/loopback
+            shutdown_seconds: 
+              type: number
+              default: 1
+    loki: 
+      type: object
+      properties: 
+        actions: 
+          type: array
+          items: 
+            type: string
+          default: [
+            "locate",
+            "route",
+            "height",
+            "sources_to_targets",
+            "optimized_route",
+            "isochrone",
+            "trace_route",
+            "trace_attributes",
+            "transit_available",
+            "expansion",
+            "centroid",
+            "status",
+          ]
+        logging: 
+          type: object
+          properties: 
+            color: 
+              type: boolean
+            file_name: 
+              type: string
+              default: path_to_some_file.log
+            long_request: 
+              type: number
+              default: 100
+            type: 
+              type: string
+              default: std_out
+        service: 
+          type: object
+          properties: 
+            proxy: 
+              type: string
+              default: ipc:///tmp/loki
+        service_defaults: 
+          type: object
+          properties: 
+            heading_tolerance: 
+              type: number
+              default: 60
+            minimum_reachability: 
+              type: number
+              default: 50
+            node_snap_tolerance: 
+              type: number
+              default: 5
+            radius: 
+              type: number
+              default: 0
+            search_cutoff: 
+              type: number
+              default: 35000
+            street_side_max_distance: 
+              type: number
+              default: 1000
+            street_side_tolerance: 
+              type: number
+              default: 5
+        use_connectivity: 
+          type: boolean
+    meili: 
+      type: object
+      properties: 
+        auto: 
+          type: object
+          properties: 
+            search_radius: 
+              type: number
+              default: 50
+            turn_penalty_factor: 
+              type: number
+              default: 200
+        bicycle: 
+          type: object
+          properties: 
+            turn_penalty_factor: 
+              type: number
+              default: 140
+        customizable: 
+          type: array
+          items: 
+            type: string
+          default: [
+            "mode",
+            "search_radius",
+            "turn_penalty_factor",
+            "gps_accuracy",
+            "interpolation_distance",
+            "sigma_z",
+            "beta",
+            "max_route_distance_factor",
+            "max_route_time_factor"
+          ]
+        default: 
+          type: object
+          properties: 
+            beta: 
+              type: number
+              default: 3
+            breakage_distance: 
+              type: number
+              default: 2000
+            geometry: 
+              type: boolean
+            gps_accuracy: 
+              type: number
+              default: 5
+            interpolation_distance: 
+              type: number
+              default: 10
+            max_route_distance_factor: 
+              type: number
+              default: 5
+            max_route_time_factor: 
+              type: number
+              default: 5
+            max_search_radius: 
+              type: number
+              default: 100
+            route: 
+              type: boolean
+            search_radius: 
+              type: number
+              default: 50
+            sigma_z: 
+              type: number
+              default: 4.07
+            turn_penalty_factor: 
+              type: number
+              default: 0
+        grid: 
+          type: object
+          properties: 
+            cache_size: 
+              type: number
+              default: 100240
+            size: 
+              type: number
+              default: 500
+        logging: 
+          type: object
+          properties: 
+            color: 
+              type: boolean
+            file_name: 
+              type: string
+              default: path_to_some_file.log
+            type: 
+              type: string
+              default: std_out
+        mode: 
+          type: string
+          default: auto
+        multimodal: 
+          type: object
+          properties: 
+            turn_penalty_factor: 
+              type: number
+              default: 70
+        pedestrian: 
+          type: object
+          properties: 
+            search_radius: 
+              type: number
+              default: 50
+            turn_penalty_factor: 
+              type: number
+              default: 100
+        service: 
+          type: object
+          properties: 
+            proxy: 
+              type: string
+              default: ipc:///tmp/meili
+        verbose: 
+          type: boolean
+    mjolnir: 
+      type: object
+      properties: 
+        admin: 
+          type: string
+          default: /custom_data/admins.sqlite
+        data_processing: 
+          type: object
+          properties: 
+            allow_alt_name: 
+              type: boolean
+            apply_country_overrides: 
+              type: boolean
+            infer_internal_intersections: 
+              type: boolean
+            infer_turn_channels: 
+              type: boolean
+            scan_tar: 
+              type: boolean
+            use_admin_db: 
+              type: boolean
+            use_direction_on_ways: 
+              type: boolean
+            use_rest_area: 
+              type: boolean
+            use_urban_tag: 
+              type: boolean
+        global_synchronized_cache: 
+          type: boolean
+        hierarchy: 
+          type: boolean
+        id_table_size: 
+          type: number
+          default: 1300000000
+        import_bike_share_stations: 
+          type: boolean
+        include_bicycle: 
+          type: boolean
+        include_construction: 
+          type: boolean
+        include_driveways: 
+          type: boolean
+        include_driving: 
+          type: boolean
+        include_pedestrian: 
+          type: boolean
+        logging: 
+          type: object
+          properties: 
+            color: 
+              type: boolean
+            file_name: 
+              type: string
+              default: path_to_some_file.log
+            type: 
+              type: string
+              default: std_out
+        lru_mem_cache_hard_control: 
+          type: boolean
+        max_cache_size: 
+          type: number
+          default: 1000000000
+        max_concurrent_reader_users: 
+          type: number
+          default: 1
+        reclassify_links: 
+          type: boolean
+        shortcuts: 
+          type: boolean
+        tile_dir: 
+          type: string
+          format: nullable
+        tile_extract: 
+          type: string
+          default: /data/user/0/com.valhalla.valhalla.test/files/valhalla_tiles.tar
+        timezone: 
+          type: string
+          default: timezones.sqlite
+        traffic_extract: 
+          type: string
+          default: 
+        transit_dir: 
+          type: string
+          default: 
+        transit_feeds_dir: 
+          type: string
+          default: /data/valhalla/transit_feeds
+        use_lru_mem_cache: 
+          type: boolean
+        use_simple_mem_cache: 
+          type: boolean
+    odin: 
+      type: object
+      properties: 
+        logging: 
+          type: object
+          properties: 
+            color: 
+              type: boolean
+            file_name: 
+              type: string
+              default: path_to_some_file.log
+            type: 
+              type: string
+              default: std_out
+        markup_formatter: 
+          type: object
+          properties: 
+            markup_enabled: 
+              type: boolean
+            phoneme_format: 
+              type: string
+              default: <TEXTUAL_STRING> (<span class=<QUOTES>phoneme<QUOTES>>/<VERBAL_STRING>/</span>)
+        service: 
+          type: object
+          properties: 
+            proxy: 
+              type: string
+              default: ipc:///tmp/odin
+    service_limits: 
+      type: object
+      properties: 
+        auto: 
+          type: object
+          properties: 
+            max_distance: 
+              type: number
+              default: 5000000
+            max_locations: 
+              type: number
+              default: 20
+            max_matrix_distance: 
+              type: number
+              default: 400000
+            max_matrix_location_pairs: 
+              type: number
+              default: 2500
+        bicycle: 
+          type: object
+          properties: 
+            max_distance: 
+              type: number
+              default: 500000
+            max_locations: 
+              type: number
+              default: 50
+            max_matrix_distance: 
+              type: number
+              default: 200000
+            max_matrix_location_pairs: 
+              type: number
+              default: 2500
+        bikeshare: 
+          type: object
+          properties: 
+            max_distance: 
+              type: number
+              default: 500000
+            max_locations: 
+              type: number
+              default: 50
+            max_matrix_distance: 
+              type: number
+              default: 200000
+            max_matrix_location_pairs: 
+              type: number
+              default: 2500
+        bus: 
+          type: object
+          properties: 
+            max_distance: 
+              type: number
+              default: 5000000
+            max_locations: 
+              type: number
+              default: 50
+            max_matrix_distance: 
+              type: number
+              default: 400000
+            max_matrix_location_pairs: 
+              type: number
+              default: 2500
+        centroid: 
+          type: object
+          properties: 
+            max_distance: 
+              type: number
+              default: 200000
+            max_locations: 
+              type: number
+              default: 5
+        isochrone: 
+          type: object
+          properties: 
+            max_contours: 
+              type: number
+              default: 4
+            max_distance: 
+              type: number
+              default: 25000
+            max_distance_contour: 
+              type: number
+              default: 200
+            max_locations: 
+              type: number
+              default: 1
+            max_time_contour: 
+              type: number
+              default: 120
+        max_alternates: 
+          type: number
+          default: 2
+        max_exclude_locations: 
+          type: number
+          default: 50
+        max_exclude_polygons_length: 
+          type: number
+          default: 10000
+        max_radius: 
+          type: number
+          default: 200
+        max_reachability: 
+          type: number
+          default: 100
+        max_timedep_distance: 
+          type: number
+          default: 500000
+        max_timedep_distance_matrix: 
+          type: number
+          default: 0
+        motor_scooter: 
+          type: object
+          properties: 
+            max_distance: 
+              type: number
+              default: 500000
+            max_locations: 
+              type: number
+              default: 50
+            max_matrix_distance: 
+              type: number
+              default: 200000
+            max_matrix_location_pairs: 
+              type: number
+              default: 2500
+        motorcycle: 
+          type: object
+          properties: 
+            max_distance: 
+              type: number
+              default: 500000
+            max_locations: 
+              type: number
+              default: 50
+            max_matrix_distance: 
+              type: number
+              default: 200000
+            max_matrix_location_pairs: 
+              type: number
+              default: 2500
+        multimodal: 
+          type: object
+          properties: 
+            max_distance: 
+              type: number
+              default: 500000
+            max_locations: 
+              type: number
+              default: 50
+            max_matrix_distance: 
+              type: number
+              default: 0
+            max_matrix_location_pairs: 
+              type: number
+              default: 0
+        pedestrian: 
+          type: object
+          properties: 
+            max_distance: 
+              type: number
+              default: 250000
+            max_locations: 
+              type: number
+              default: 50
+            max_matrix_distance: 
+              type: number
+              default: 200000
+            max_matrix_location_pairs: 
+              type: number
+              default: 2500
+            max_transit_walking_distance: 
+              type: number
+              default: 10000
+            min_transit_walking_distance: 
+              type: number
+              default: 1
+        skadi: 
+          type: object
+          properties: 
+            max_shape: 
+              type: number
+              default: 750000
+            min_resample: 
+              type: number
+              default: 10
+        status: 
+          type: object
+          properties: 
+            allow_verbose: 
+              type: boolean
+        taxi: 
+          type: object
+          properties: 
+            max_distance: 
+              type: number
+              default: 5000000
+            max_locations: 
+              type: number
+              default: 20
+            max_matrix_distance: 
+              type: number
+              default: 400000
+            max_matrix_location_pairs: 
+              type: number
+              default: 2500
+        trace: 
+          type: object
+          properties: 
+            max_alternates: 
+              type: number
+              default: 3
+            max_alternates_shape: 
+              type: number
+              default: 100
+            max_distance: 
+              type: number
+              default: 200000
+            max_gps_accuracy: 
+              type: number
+              default: 100
+            max_search_radius: 
+              type: number
+              default: 100
+            max_shape: 
+              type: number
+              default: 16000
+        transit: 
+          type: object
+          properties: 
+            max_distance: 
+              type: number
+              default: 500000
+            max_locations: 
+              type: number
+              default: 50
+            max_matrix_distance: 
+              type: number
+              default: 200000
+            max_matrix_location_pairs: 
+              type: number
+              default: 2500
+        truck: 
+          type: object
+          properties: 
+            max_distance: 
+              type: number
+              default: 5000000
+            max_locations: 
+              type: number
+              default: 20
+            max_matrix_distance: 
+              type: number
+              default: 400000
+            max_matrix_location_pairs: 
+              type: number
+              default: 2500
+    statsd: 
+      type: object
+      properties: 
+        port: 
+          type: number
+          default: 8125
+        prefix: 
+          type: string
+          default: valhalla
+    thor: 
+      type: object
+      properties: 
+        clear_reserved_memory: 
+          type: boolean
+        extended_search: 
+          type: boolean
+        logging: 
+          type: object
+          properties: 
+            color: 
+              type: boolean
+            file_name: 
+              type: string
+              default: path_to_some_file.log
+            long_request: 
+              type: number
+              default: 110
+            type: 
+              type: string
+              default: std_out
+        max_reserved_labels_count: 
+          type: number
+          default: 1000000
+        service: 
+          type: object
+          properties: 
+            proxy: 
+              type: string
+              default: ipc:///tmp/thor
+        source_to_target_algorithm: 
+          type: string
+          default: select_optimal

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,4 +3,10 @@ plugins {
 }
 
 rootProject.name = "valhalla-api-kotlin"
+
+gradle.beforeProject {
+    extensions.extraProperties["libraryVersion"] = "0.0.2"
+}
+
 include("client")
+include("config")


### PR DESCRIPTION
- Adds an auto generated Valhalla config `openapi-config.yaml`. This is a starting point and probably has errors, but should get a bit closer to testing Valhalla config generation in the core Valhalla-mobile library.